### PR TITLE
Ability for Users to Choose Event for FTP Upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
+.idea
 
 # C extensions
 *.so

--- a/install/settings.json
+++ b/install/settings.json
@@ -19,6 +19,21 @@
       "name": "plugin"
     },
     "setting": {
+      "description": "Which stage to use when sending files to the FTP server.",
+      "is_translatable": false,
+      "name": "transport_production_stage",
+      "pretty_name": "Production Manager Stage",
+      "type": "select"
+    },
+    "value": {
+      "default": ""
+    }
+  },
+  {
+    "group": {
+      "name": "plugin"
+    },
+    "setting": {
       "description": "Contact email address of production manager.",
       "is_translatable": false,
       "name": "transport_production_manager",

--- a/install/settings.json
+++ b/install/settings.json
@@ -19,7 +19,7 @@
       "name": "plugin"
     },
     "setting": {
-      "description": "Which stage to use when sending files to the FTP server.",
+      "description": "Defines the stage which triggers depositing the article into the FTP server. The article is deposited upon entering the chosen stage.",
       "is_translatable": false,
       "name": "transport_production_stage",
       "pretty_name": "Production Manager Stage",

--- a/install/settings.json
+++ b/install/settings.json
@@ -4,7 +4,7 @@
       "name": "plugin"
     },
     "setting": {
-      "description": "When enabled the article will automatically be deposited on acceptance.",
+      "description": "When enabled the article will automatically be deposited on the stage set by \"Production Manager Stage\".",
       "is_translatable": false,
       "name": "enable_transport",
       "pretty_name": "Enable Transport",
@@ -26,7 +26,7 @@
       "type": "select"
     },
     "value": {
-      "default": ""
+      "default": "Accepted"
     }
   },
   {

--- a/plugin_settings.py
+++ b/plugin_settings.py
@@ -56,3 +56,13 @@ def register_for_events():
         events_logic.Events.ON_ARTICLE_ACCEPTED,
         utils.on_article_accepted,
     )
+
+    events_logic.Events.register_for_event(
+        events_logic.Events.ON_ARTICLE_SUBMITTED,
+        utils.on_article_submitted,
+    )
+
+    events_logic.Events.register_for_event(
+        events_logic.Events.ON_ARTICLE_PUBLISHED,
+        utils.on_article_published,
+    )

--- a/views.py
+++ b/views.py
@@ -9,6 +9,7 @@ from core import forms, files
 from submission import models
 from utils import setting_handler
 from security.decorators import has_journal, any_editor_user_required
+from submission import models as submission_models
 
 
 @has_journal
@@ -18,6 +19,15 @@ def index(request):
         {
             'name': 'enable_transport',
             'object': setting_handler.get_setting('plugin', 'enable_transport', request.journal),
+        },
+        {
+            'name': 'transport_production_stage',
+            'object': setting_handler.get_setting('plugin', 'transport_production_stage', request.journal),
+            'choices': [
+                [submission_models.STAGE_ACCEPTED,'Accepted'],
+                [submission_models.STAGE_UNASSIGNED,'Submitted'],
+                [submission_models.STAGE_PUBLISHED,'Published']
+            ]
         },
         {
             'name': 'transport_production_manager',


### PR DESCRIPTION
This PR introduces the ability for a user to choose which event causes the upload to the FTP server. 

These events are "Accepted" (Default), "Submitted", and "Published".

Below previews this setting within the Production Transporter area. 
<img width="759" alt="Screenshot 2025-05-27 at 7 21 06 AM" src="https://github.com/user-attachments/assets/d2862284-6f55-4e57-8ced-fbbee25964b9" />
<img width="798" alt="Screenshot 2025-05-27 at 7 20 57 AM" src="https://github.com/user-attachments/assets/1277c022-0fb6-4180-942f-c3198990e004" />

